### PR TITLE
Update index.js (type: "maintianed" should be "maintained"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ declaring it in its dependencies. This is currently working because
 node_modules folder for unrelated reasons, but it \x1B[1mmay break at any time\x1B[0;33m.
 
 babel-preset-react-app is part of the create-react-app project, \x1B[1mwhich
-is not maintianed anymore\x1B[0;33m. It is thus unlikely that this bug will
+is not maintained anymore\x1B[0;33m. It is thus unlikely that this bug will
 ever be fixed. Add "@babel/plugin-proposal-private-property-in-object" to
 your devDependencies to work around this error. This will make this message
 go away.\x1B[0m


### PR DESCRIPTION
Notice this typo when running a React project created with create-react-app:

<img width="730" alt="Screenshot 2023-06-09 at 9 44 30" src="https://github.com/babel/babel-plugin-proposal-private-property-in-object/assets/104947308/43112f95-29c8-4d81-a285-a4efeba2d46b">

Sorry to bother with such a small fix, just thought you might want to know!